### PR TITLE
fix(dataset-client): never rely on dataset.itemCount

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.8.1",
             "license": "Apache-2.0",
             "dependencies": {
+                "@apify/consts": "^2.52.1",
                 "apify": "^3.7.0",
                 "apify-client": "^2.22.3"
             },
@@ -32,9 +33,9 @@
             }
         },
         "node_modules/@apify/consts": {
-            "version": "2.51.0",
-            "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.51.0.tgz",
-            "integrity": "sha512-pW9VxTP0H99Gn8JAk2DUdXynASja0vaB2JH8pmF8JbE7WThV21+p7KLPf5EwZ5gAgaw9OY/qDx0slI4iENgyjQ==",
+            "version": "2.52.1",
+            "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.52.1.tgz",
+            "integrity": "sha512-Nhal8FiIgAw5ylVL4U2DAeJJyKow0bFObAX/og5BJjB9xJ2csQcyVAx4ChnO7XOaeRU8HbRn9u0QUGzPt5NNqA==",
             "license": "Apache-2.0"
         },
         "node_modules/@apify/datastructures": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "devDependencies": {
         "@apify/eslint-config": "^1.1.0",
         "@apify/tsconfig": "^0.1.1",
+        "@crawlee/types": "^3.16.0",
         "@vitest/coverage-v8": "^4.1.2",
         "axios": "^1.14.0",
         "eslint": "^9.39.4",
@@ -47,10 +48,10 @@
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.58.0",
         "vite-tsconfig-paths": "^6.1.1",
-        "vitest": "^4.1.2",
-        "@crawlee/types": "^3.16.0"
+        "vitest": "^4.1.2"
     },
     "dependencies": {
+        "@apify/consts": "^2.52.1",
         "apify": "^3.7.0",
         "apify-client": "^2.22.3"
     },

--- a/src/clients/dataset-client.ts
+++ b/src/clients/dataset-client.ts
@@ -1,5 +1,7 @@
-import type { ActorRun, Dataset } from 'apify-client';
 import { DatasetClient } from 'apify-client';
+import { isDefined } from 'src/utils/typing.js';
+
+import { ACTOR_JOB_TERMINAL_STATUSES } from '@apify/consts';
 
 import type { OrchestratorContext } from '../context/orchestrator-context.js';
 import type { DatasetItem, ExtendedDatasetClient, GreedyIterateOptions, IterateOptions } from '../types.js';
@@ -52,56 +54,48 @@ export class ExtDatasetClient<T extends DatasetItem> extends DatasetClient<T> im
     }
 
     async *greedyIterate(options: GreedyIterateOptions = {}): AsyncGenerator<T, void, void> {
-        const { pageSize = 100, itemsThreshold = 100, pollIntervalSecs = 10, ...listItemOptions } = options;
+        const { pageSize = 100, pollIntervalSecs = 10, ...listItemOptions } = options;
         this.context.logger.info('Greedily iterating Dataset', { pageSize }, { url: this.url });
 
         let readItemsCount = 0;
 
-        let dataset: Dataset | undefined;
-        let run: ActorRun | undefined;
-
-        // TODO: breaking change - remove itemsThreshold and just listItems at every iteration
+        // Poll the run status and fetch newly available items at each interval.
         while (true) {
-            dataset = await this.get();
-            if (!dataset || !dataset.actRunId) {
+            const dataset = await this.get();
+            if (!isDefined(dataset?.actRunId)) {
                 this.context.logger.error('Error getting Dataset while iterating greedily', { id: this.id });
                 return;
             }
 
-            run = await this.apifyClient.run(dataset.actRunId).get();
-            if (!run) {
+            const run = await this.apifyClient.run(dataset.actRunId).get();
+            if (!isDefined(run)) {
                 this.context.logger.error('Error getting Run while iterating Dataset greedily', { id: this.id });
                 return;
             }
 
-            if (run.status !== 'READY' && run.status !== 'RUNNING') {
+            const itemList = await super.listItems({
+                ...listItemOptions,
+                offset: readItemsCount,
+                limit: pageSize,
+            });
+            readItemsCount += itemList.count;
+            for (const item of itemList.items) {
+                yield item;
+            }
+
+            const isTerminal = (ACTOR_JOB_TERMINAL_STATUSES as readonly string[]).includes(run.status);
+            if (isTerminal) {
                 break;
             }
 
-            if (dataset.itemCount >= readItemsCount + itemsThreshold) {
-                const itemList = await super.listItems({
-                    ...listItemOptions,
-                    offset: readItemsCount,
-                    limit: pageSize,
-                });
-                readItemsCount += itemList.count;
-                for (const item of itemList.items) {
-                    yield item;
-                }
-            }
-
-            await new Promise((resolve) => {
+            await new Promise<void>((resolve) => {
                 setTimeout(resolve, pollIntervalSecs * 1000);
             });
         }
 
-        dataset = await this.get();
-        if (!dataset || !dataset.actRunId) {
-            this.context.logger.error('Error getting Dataset while iterating greedily', { id: this.id });
-            return;
-        }
-
-        while (readItemsCount < dataset.itemCount) {
+        // Drain any remaining items. We cannot rely on dataset.itemCount here because it is
+        // eventually consistent — instead we keep fetching pages until we receive an empty one.
+        while (true) {
             const itemList = await super.listItems({
                 ...listItemOptions,
                 offset: readItemsCount,

--- a/src/types.ts
+++ b/src/types.ts
@@ -420,25 +420,19 @@ export interface ExtendedDatasetClient<T extends DatasetItem> extends DatasetCli
     iterate: (options: IterateOptions) => AsyncGenerator<T, void, void>;
 
     /**
-     * Iterates over the items in the dataset. Fetches the items as soon as they are available
+     * Iterates over the items in the dataset as they become available, polling the run status
+     * at a regular interval and yielding any new items found at each poll.
      *
      * The option `pageSize` will help avoiding the JavaScript's string limit when deserializing the content.
-     * The default value is 100 items.
-     *
-     * The option `itemsThreshold` will define the batch size of new items to trigger a fetch.
-     * Set to 0 to fetch any amount of new items as soon as they are available.
      * The default value is 100 items.
      *
      * The option `pollIntervalSecs` allows customizing how frequently to call the API to check for new items.
      * The default value is 10 seconds.
      *
-     * ### Example
+     * Once the run reaches a terminal status, any remaining items are drained page-by-page until
+     * no more are returned.
      *
-     * With the default settings, this function will check every 10 seconds if at least 100 new items are available.
-     * If yes, it will read a "page" of 100 items from the dataset, then resume polling every 10 seconds.
-     * If the Run terminates, it will fetch all the remaining items using a pagination of 100 items.
-     *
-     * @param options includes all the options in `DatasetClientListItemOptions`, `pageSize`, `itemsThreshold`, and `pollIntervalSecs`
+     * @param options includes all the options in `DatasetClientListItemOptions`, `pageSize`, and `pollIntervalSecs`
      * @returns an `AsyncGenerator` which iterates the items in the dataset
      *
      * @example
@@ -518,13 +512,6 @@ export type IterateOptions = DatasetClientListItemOptions & {
 };
 
 export type GreedyIterateOptions = IterateOptions & {
-    /**
-     * Download new items when they are more than the specified threshold, or when the Run terminates.\
-     * If zero, the new items are downloaded as soon as they are detected.
-     *
-     * @default 100
-     */
-    itemsThreshold?: number;
     /**
      * Check the run's status regularly at the specified interval, in seconds.
      *


### PR DESCRIPTION
Given [this](https://console.apify.com/view/runs/sVJue2QwgxqcCqOmh) actor run, it seems we still don't consistently iterate datasets - this is a breaking change, but in significantly simplifies the logic