### PR TITLE
feat(dataset-client): introduce batched greedy iterator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "apify-orchestrator",
-    "version": "0.9.0-rc.1",
+    "version": "0.9.0-rc.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "apify-orchestrator",
-            "version": "0.9.0-rc.1",
+            "version": "0.9.0-rc.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apify/consts": "^2.52.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "apify-orchestrator",
-    "version": "0.9.0-rc.1",
+    "version": "0.9.0-rc.2",
     "description": "Utilities to orchestrate Apify Actors.",
     "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
         "*.{js,ts,mjs}": [
             "eslint",
             "prettier --check",
-            "vitest related --run --config vitest.unit.config.ts"
+            "vitest related --run"
         ],
         "*.{json,md,yml,yaml}": [
             "prettier --check"

--- a/src/__e2e__/dataset-tests.ts
+++ b/src/__e2e__/dataset-tests.ts
@@ -1,0 +1,172 @@
+import type { ExtendedDatasetClient } from '../types.js';
+import type { Output, TestResult } from './types.js';
+import { generateActorTestRunner, getOrchestratorAndClient } from './utils.js';
+
+const TEST_VALUES = [1, 2, 3, 4, 5];
+const PAGE_SIZE = 2;
+const GREEDY_POLL_INTERVAL_SECS = 2;
+const CHILD_OUTPUT_INTERVAL_SECS = 2;
+
+function valuesMatch(actual: number[], expected: number[]): boolean {
+    return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+export async function datasetIteration(): Promise<TestResult> {
+    const { client } = await getOrchestratorAndClient({
+        persistenceSupport: 'none',
+        hideSensitiveInformation: false,
+    });
+
+    const runner = await generateActorTestRunner(client);
+
+    const run = await runner.call(1, { numbersToOutput: TEST_VALUES });
+    if (!run) {
+        return { success: false, details: 'Run was not started successfully.' };
+    }
+
+    const dataset = client.dataset<Output>(run.run.defaultDatasetId);
+
+    const readItems: number[] = [];
+    for await (const item of dataset.iterate({ pageSize: PAGE_SIZE })) {
+        readItems.push(item.value);
+    }
+    if (!valuesMatch(readItems, TEST_VALUES)) {
+        return { success: false, details: `Unexpected items from iterate: ${JSON.stringify(readItems)}` };
+    }
+
+    const readBatches: number[][] = [];
+    for await (const batch of dataset.iterateBatched({ pageSize: PAGE_SIZE })) {
+        readBatches.push(batch.map((item) => item.value));
+    }
+    if (readBatches.some((batch) => batch.length === 0 || batch.length > PAGE_SIZE)) {
+        return {
+            success: false,
+            details: `Unexpected batch sizes from iterateBatched: ${JSON.stringify(readBatches)}`,
+        };
+    }
+    if (!valuesMatch(readBatches.flat(), TEST_VALUES)) {
+        return { success: false, details: `Unexpected items from iterateBatched: ${JSON.stringify(readBatches)}` };
+    }
+
+    const unpaginatedBatches: number[][] = [];
+    for await (const batch of dataset.iterateBatched({})) {
+        unpaginatedBatches.push(batch.map((item) => item.value));
+    }
+    if (unpaginatedBatches.length !== 1 || !valuesMatch(unpaginatedBatches[0], TEST_VALUES)) {
+        return {
+            success: false,
+            details: `Unexpected batches from iterateBatched without pageSize: ${JSON.stringify(unpaginatedBatches)}`,
+        };
+    }
+
+    return { success: true };
+}
+
+export async function greedyDatasetIteration(): Promise<TestResult> {
+    const { client } = await getOrchestratorAndClient({
+        persistenceSupport: 'none',
+        hideSensitiveInformation: false,
+    });
+
+    const runner = await generateActorTestRunner(client);
+
+    // Start the run without waiting for it to finish, so that the parent iterates the dataset
+    // greedily while the child is still producing items.
+    const run = await runner.start(1, { numbersToOutput: TEST_VALUES, outputIntervalSecs: CHILD_OUTPUT_INTERVAL_SECS });
+    if (!run) {
+        return { success: false, details: 'Run was not started successfully.' };
+    }
+
+    const dataset = client.dataset<Output>(run.run.defaultDatasetId);
+
+    // Both greedy iterators poll the same dataset independently, so they can run concurrently.
+    const [readItems, readBatches] = await Promise.all([collectGreedyItems(dataset), collectGreedyBatches(dataset)]);
+
+    if (!valuesMatch(readItems, TEST_VALUES)) {
+        return { success: false, details: `Unexpected items from greedyIterate: ${JSON.stringify(readItems)}` };
+    }
+    if (readBatches.some((batch) => batch.length === 0 || batch.length > PAGE_SIZE)) {
+        return {
+            success: false,
+            details: `Unexpected batch sizes from greedyIterateBatched: ${JSON.stringify(readBatches)}`,
+        };
+    }
+    if (!valuesMatch(readBatches.flat(), TEST_VALUES)) {
+        return {
+            success: false,
+            details: `Unexpected items from greedyIterateBatched: ${JSON.stringify(readBatches)}`,
+        };
+    }
+
+    return { success: true };
+}
+
+export async function mergedDatasetIteration(): Promise<TestResult> {
+    const { orchestrator, client } = await getOrchestratorAndClient({
+        persistenceSupport: 'none',
+        hideSensitiveInformation: false,
+    });
+
+    const runner = await generateActorTestRunner(client);
+
+    const [run1, run2] = await Promise.all([
+        runner.call(1, { numbersToOutput: [1, 2, 3] }),
+        runner.call(2, { numbersToOutput: [4, 5] }),
+    ]);
+    if (!run1 || !run2) {
+        return { success: false, details: 'One of the runs was not started successfully.' };
+    }
+
+    const mergedDatasets = orchestrator.mergeDatasets(
+        client.dataset<Output>(run1.run.defaultDatasetId),
+        client.dataset<Output>(run2.run.defaultDatasetId),
+    );
+
+    const readItems: number[] = [];
+    for await (const item of mergedDatasets.iterate({ pageSize: PAGE_SIZE })) {
+        readItems.push(item.value);
+    }
+    if (!valuesMatch(readItems, TEST_VALUES)) {
+        return { success: false, details: `Unexpected items from merged iterate: ${JSON.stringify(readItems)}` };
+    }
+
+    const readBatches: number[][] = [];
+    for await (const batch of mergedDatasets.iterateBatched({ pageSize: PAGE_SIZE })) {
+        readBatches.push(batch.map((item) => item.value));
+    }
+    if (readBatches.some((batch) => batch.length === 0 || batch.length > PAGE_SIZE)) {
+        return {
+            success: false,
+            details: `Unexpected batch sizes from merged iterateBatched: ${JSON.stringify(readBatches)}`,
+        };
+    }
+    if (!valuesMatch(readBatches.flat(), TEST_VALUES)) {
+        return {
+            success: false,
+            details: `Unexpected items from merged iterateBatched: ${JSON.stringify(readBatches)}`,
+        };
+    }
+
+    return { success: true };
+}
+
+async function collectGreedyItems(dataset: ExtendedDatasetClient<Output>): Promise<number[]> {
+    const values: number[] = [];
+    const iterator = dataset.greedyIterate({ pageSize: PAGE_SIZE, pollIntervalSecs: GREEDY_POLL_INTERVAL_SECS });
+    for await (const item of iterator) {
+        values.push(item.value);
+    }
+    return values;
+}
+
+async function collectGreedyBatches(dataset: ExtendedDatasetClient<Output>): Promise<number[][]> {
+    const batches: number[][] = [];
+    const iterator = dataset.greedyIterateBatched({
+        pageSize: PAGE_SIZE,
+        pollIntervalSecs: GREEDY_POLL_INTERVAL_SECS,
+    });
+    for await (const batch of iterator) {
+        batches.push(batch.map((item) => item.value));
+    }
+    return batches;
+}

--- a/src/__e2e__/test-actor-runner.ts
+++ b/src/__e2e__/test-actor-runner.ts
@@ -29,8 +29,12 @@ export class TestActorRunner {
         return new TestActorRunner(client, actorId, options);
     }
 
-    async start(index: number, numberToOutput?: number): Promise<TestRun | null> {
-        const childInput: Input = { role: 'child', waitSeconds: this.options.childWaitSeconds, numberToOutput };
+    async start(index: number, input?: Partial<Omit<Input, 'role' | 'waitSeconds'>>): Promise<TestRun | null> {
+        const childInput: Input = {
+            role: 'child',
+            waitSeconds: this.options.childWaitSeconds,
+            ...input,
+        };
         const childOptions: ActorCallOptions = { memory: this.options.childMemoryMbytes };
         const runName = `child-${index}`;
         try {
@@ -46,8 +50,8 @@ export class TestActorRunner {
         }
     }
 
-    async call(index: number, numberToOutput?: number): Promise<TestRun | null> {
-        const startedRun = await this.start(index, numberToOutput);
+    async call(index: number, input?: Partial<Omit<Input, 'role' | 'waitSeconds'>>): Promise<TestRun | null> {
+        const startedRun = await this.start(index, input);
         if (!startedRun) return null;
         const finishedRun = await this.apifyClient.run(startedRun.run.id).waitForFinish();
         return new TestRun(this.apifyClient, finishedRun, startedRun.runName);

--- a/src/__e2e__/test-suite.ts
+++ b/src/__e2e__/test-suite.ts
@@ -1,6 +1,7 @@
 import { log } from 'apify';
 
 import type { TrackedRuns } from '../run-tracker.js';
+import { datasetIteration, greedyDatasetIteration, mergedDatasetIteration } from './dataset-tests.js';
 import { checkResurrectionTestOutputCompleteness, runResurrectionTest } from './resurrection.js';
 import { TestTransientTaskRunner } from './transient-task-runner.js';
 import type { TestResult } from './types.js';
@@ -14,6 +15,9 @@ export async function runEndToEndTestSuite(): Promise<EndToEndTestOutput> {
         childRunWithPlainPersistence,
         childRunWithEncryptedPersistence,
         childRunFromTask,
+        datasetIteration,
+        greedyDatasetIteration,
+        mergedDatasetIteration,
         resurrectedRunWithoutPersistence,
         resurrectedRunWithPlainPersistence,
         resurrectedRunWithEncryptedPersistence,
@@ -47,7 +51,7 @@ async function childRunWithoutPersistence(): Promise<TestResult> {
     const [run1, run2, run3] = await Promise.all(
         Array.from({ length: 3 }).map(async (_, index) => {
             const childNumber = index + 1;
-            return runner.call(childNumber, childNumber * 10);
+            return runner.call(childNumber, { numbersToOutput: [childNumber * 10] });
         }),
     );
 
@@ -74,7 +78,7 @@ async function childRunWithPlainPersistence(): Promise<TestResult> {
 
     const runner = await generateActorTestRunner(client);
 
-    const run = await runner.call(1, 42);
+    const run = await runner.call(1, { numbersToOutput: [42] });
     if (!run) {
         return { success: false, details: 'Run was not started successfully.' };
     }
@@ -106,7 +110,7 @@ async function childRunWithEncryptedPersistence(): Promise<TestResult> {
 
     const runner = await generateActorTestRunner(client);
 
-    const run = await runner.call(1, 84);
+    const run = await runner.call(1, { numbersToOutput: [84] });
     if (!run) {
         return { success: false, details: 'Run was not started successfully.' };
     }
@@ -136,7 +140,7 @@ async function childRunFromTask(): Promise<TestResult> {
         hideSensitiveInformation: false,
     });
 
-    using runner = await TestTransientTaskRunner.new(client, 'e2e-child-task-runner', 50);
+    using runner = await TestTransientTaskRunner.new(client, 'e2e-child-task-runner', { numbersToOutput: [50] });
 
     const run = await runner.call(1);
     if (!run) {

--- a/src/__e2e__/transient-task-runner.ts
+++ b/src/__e2e__/transient-task-runner.ts
@@ -3,6 +3,7 @@ import { log } from 'apify';
 import type { ExtendedApifyClient } from '../types.js';
 import { getActorId } from './actor-id.js';
 import { TestTaskRunner } from './test-task-runner.js';
+import type { Input } from './types.js';
 
 export class TestTransientTaskRunner extends TestTaskRunner {
     private readonly taskName: string;
@@ -15,12 +16,12 @@ export class TestTransientTaskRunner extends TestTaskRunner {
     static async new(
         client: ExtendedApifyClient,
         taskName: string,
-        numberToOutput?: number,
+        input: Partial<Omit<Input, 'role' | 'waitSeconds'>> = {},
     ): Promise<TestTransientTaskRunner> {
         const actorId = await getActorId();
         const task = await client
             .tasks()
-            .create({ name: taskName, actId: actorId, input: { role: 'child', waitSeconds: 2, numberToOutput } });
+            .create({ name: taskName, actId: actorId, input: { role: 'child', waitSeconds: 2, ...input } });
         return new TestTransientTaskRunner(client, task.id, taskName);
     }
 

--- a/src/__e2e__/types.ts
+++ b/src/__e2e__/types.ts
@@ -4,7 +4,8 @@ export interface Input {
     role: 'e2e-test' | 'resurrection-test' | 'child';
     orchestratorOptions?: Record<string, unknown>;
     waitSeconds?: number;
-    numberToOutput?: number;
+    numbersToOutput?: number[];
+    outputIntervalSecs?: number;
 }
 
 export interface Output extends DatasetItem {

--- a/src/clients/dataset-client.test.ts
+++ b/src/clients/dataset-client.test.ts
@@ -1,7 +1,9 @@
-import { DatasetClient } from 'apify-client';
+import type { Dataset } from 'apify-client';
+import { DatasetClient, RunClient } from 'apify-client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getClientContext } from '../__unit__/context.js';
+import { createActorRunMock } from '../__unit__/mocks.js';
 import type { DatasetItem } from '../types.js';
 import { ExtApifyClient } from './apify-client.js';
 import type { ExtDatasetClient } from './dataset-client.js';
@@ -86,6 +88,24 @@ describe('ExtDatasetClient', () => {
             expect(listItemsSpy).toHaveBeenNthCalledWith(2, { offset: 2, limit: 2 });
             expect(listItemsSpy).toHaveBeenNthCalledWith(3, { offset: 4, limit: 2 });
         });
+
+        it('yields no items when the dataset is empty', async () => {
+            const listItemsSpy = vi.spyOn(DatasetClient.prototype, 'listItems').mockResolvedValue({
+                count: 0,
+                items: [],
+                total: 0,
+                offset: 0,
+                limit: 1000,
+                desc: true,
+            });
+            const datasetIterator = datasetClient.iterate();
+            const readItems: TestItem[] = [];
+            for await (const item of datasetIterator) {
+                readItems.push(item);
+            }
+            expect(readItems).toEqual([]);
+            expect(listItemsSpy).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe('iterateBatched', () => {
@@ -157,15 +177,170 @@ describe('ExtDatasetClient', () => {
             expect(listItemsSpy).toHaveBeenNthCalledWith(2, { offset: 2, limit: 2 });
             expect(listItemsSpy).toHaveBeenNthCalledWith(3, { offset: 4, limit: 2 });
         });
+
+        it('yields no batches when the dataset is empty', async () => {
+            const listItemsSpy = vi.spyOn(DatasetClient.prototype, 'listItems').mockResolvedValue({
+                count: 0,
+                items: [],
+                total: 0,
+                offset: 0,
+                limit: 1000,
+                desc: true,
+            });
+            const datasetIterator = datasetClient.iterateBatched();
+            const batches: TestItem[][] = [];
+            for await (const batch of datasetIterator) {
+                batches.push(batch);
+            }
+            expect(batches).toEqual([]);
+            expect(listItemsSpy).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe('greedyIterate', () => {
-        it('iterates the items from the dataset as soon as one batch is available, using pagination', () => {
-            // TODO: test
+        it('iterates the items as they become available, then drains the remaining ones after the run finishes', async () => {
+            const getDatasetSpy = vi
+                .spyOn(DatasetClient.prototype, 'get')
+                .mockResolvedValue({ actRunId: 'test-run-id' } as Dataset);
+            const getRunSpy = vi
+                .spyOn(RunClient.prototype, 'get')
+                .mockResolvedValueOnce(createActorRunMock({ status: 'RUNNING' }))
+                .mockResolvedValueOnce(createActorRunMock({ status: 'SUCCEEDED' }));
+            const listItemsSpy = vi
+                .spyOn(DatasetClient.prototype, 'listItems')
+                // First poll: the run is still running, two items are available.
+                .mockResolvedValueOnce({
+                    count: 2,
+                    items: testItems.slice(0, 2),
+                    total: 2,
+                    offset: 0,
+                    limit: 2,
+                    desc: true,
+                })
+                // Second poll: the run has succeeded, one new item is available.
+                .mockResolvedValueOnce({
+                    count: 1,
+                    items: testItems.slice(2, 3),
+                    total: 3,
+                    offset: 2,
+                    limit: 2,
+                    desc: true,
+                })
+                // Drain: no more items.
+                .mockResolvedValueOnce({
+                    count: 0,
+                    items: [],
+                    total: 3,
+                    offset: 3,
+                    limit: 2,
+                    desc: true,
+                });
+
+            const datasetIterator = datasetClient.greedyIterate({ pageSize: 2, pollIntervalSecs: 0 });
+            const readItems: TestItem[] = [];
+            for await (const item of datasetIterator) {
+                readItems.push(item);
+            }
+
+            expect(readItems).toEqual(testItems);
+            expect(getDatasetSpy).toHaveBeenCalledTimes(2);
+            expect(getRunSpy).toHaveBeenCalledTimes(2);
+            expect(listItemsSpy).toHaveBeenCalledTimes(3);
+            expect(listItemsSpy).toHaveBeenNthCalledWith(1, { offset: 0, limit: 2 });
+            expect(listItemsSpy).toHaveBeenNthCalledWith(2, { offset: 2, limit: 2 });
+            expect(listItemsSpy).toHaveBeenNthCalledWith(3, { offset: 3, limit: 2 });
         });
 
-        it('iterates the items from the dataset as soon as new items are available, setting pageSize to 0', () => {
-            // TODO: test
+        it('stops without yielding items if the dataset has no associated run', async () => {
+            vi.spyOn(DatasetClient.prototype, 'get').mockResolvedValue({ actRunId: undefined } as Dataset);
+            const listItemsSpy = vi.spyOn(DatasetClient.prototype, 'listItems');
+
+            const datasetIterator = datasetClient.greedyIterate({ pageSize: 2, pollIntervalSecs: 0 });
+            const readItems: TestItem[] = [];
+            for await (const item of datasetIterator) {
+                readItems.push(item);
+            }
+
+            expect(readItems).toEqual([]);
+            expect(listItemsSpy).not.toHaveBeenCalled();
+        });
+
+        it('stops without yielding items if the associated run cannot be retrieved', async () => {
+            vi.spyOn(DatasetClient.prototype, 'get').mockResolvedValue({ actRunId: 'test-run-id' } as Dataset);
+            vi.spyOn(RunClient.prototype, 'get').mockResolvedValue(undefined);
+            const listItemsSpy = vi.spyOn(DatasetClient.prototype, 'listItems');
+
+            const datasetIterator = datasetClient.greedyIterate({ pageSize: 2, pollIntervalSecs: 0 });
+            const readItems: TestItem[] = [];
+            for await (const item of datasetIterator) {
+                readItems.push(item);
+            }
+
+            expect(readItems).toEqual([]);
+            expect(listItemsSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('greedyIterateBatched', () => {
+        it('iterates batches as they become available, skipping empty polls', async () => {
+            vi.spyOn(DatasetClient.prototype, 'get').mockResolvedValue({ actRunId: 'test-run-id' } as Dataset);
+            const getRunSpy = vi
+                .spyOn(RunClient.prototype, 'get')
+                .mockResolvedValueOnce(createActorRunMock({ status: 'RUNNING' }))
+                .mockResolvedValueOnce(createActorRunMock({ status: 'RUNNING' }))
+                .mockResolvedValueOnce(createActorRunMock({ status: 'SUCCEEDED' }));
+            const listItemsSpy = vi
+                .spyOn(DatasetClient.prototype, 'listItems')
+                // First poll: the run is still running, two items are available.
+                .mockResolvedValueOnce({
+                    count: 2,
+                    items: testItems.slice(0, 2),
+                    total: 2,
+                    offset: 0,
+                    limit: 2,
+                    desc: true,
+                })
+                // Second poll: the run is still running, no new items yet.
+                .mockResolvedValueOnce({
+                    count: 0,
+                    items: [],
+                    total: 2,
+                    offset: 2,
+                    limit: 2,
+                    desc: true,
+                })
+                // Third poll: the run has succeeded, one new item is available.
+                .mockResolvedValueOnce({
+                    count: 1,
+                    items: testItems.slice(2, 3),
+                    total: 3,
+                    offset: 2,
+                    limit: 2,
+                    desc: true,
+                })
+                // Drain: no more items.
+                .mockResolvedValueOnce({
+                    count: 0,
+                    items: [],
+                    total: 3,
+                    offset: 3,
+                    limit: 2,
+                    desc: true,
+                });
+
+            const datasetIterator = datasetClient.greedyIterateBatched({ pageSize: 2, pollIntervalSecs: 0 });
+            const batches: TestItem[][] = [];
+            for await (const batch of datasetIterator) {
+                batches.push(batch);
+            }
+
+            expect(batches).toEqual([testItems.slice(0, 2), testItems.slice(2, 3)]);
+            expect(getRunSpy).toHaveBeenCalledTimes(3);
+            expect(listItemsSpy).toHaveBeenCalledTimes(4);
+            expect(listItemsSpy).toHaveBeenNthCalledWith(1, { offset: 0, limit: 2 });
+            expect(listItemsSpy).toHaveBeenNthCalledWith(2, { offset: 2, limit: 2 });
+            expect(listItemsSpy).toHaveBeenNthCalledWith(3, { offset: 2, limit: 2 });
+            expect(listItemsSpy).toHaveBeenNthCalledWith(4, { offset: 3, limit: 2 });
         });
     });
 });

--- a/src/clients/dataset-client.test.ts
+++ b/src/clients/dataset-client.test.ts
@@ -70,17 +70,88 @@ describe('ExtDatasetClient', () => {
                     count: 0,
                     items: [],
                     total: 3,
-                    offset: 4,
+                    offset: 3,
                     limit: 2,
                     desc: true,
                 });
             const datasetIterator = datasetClient.iterate({ pageSize: 2 });
-            let index = 0;
+            let itemCount = 0;
             for await (const item of datasetIterator) {
-                expect(item).toEqual(testItems[index]);
-                index++;
+                expect(item).toEqual(testItems[itemCount]);
+                itemCount++;
             }
-            expect(index).toBe(3);
+            expect(itemCount).toBe(3);
+            expect(listItemsSpy).toHaveBeenCalledTimes(3);
+            expect(listItemsSpy).toHaveBeenNthCalledWith(1, { offset: 0, limit: 2 });
+            expect(listItemsSpy).toHaveBeenNthCalledWith(2, { offset: 2, limit: 2 });
+            expect(listItemsSpy).toHaveBeenNthCalledWith(3, { offset: 4, limit: 2 });
+        });
+    });
+
+    describe('iterateBatched', () => {
+        it('iterates batches of items from the dataset', async () => {
+            const listItemsSpy = vi.spyOn(DatasetClient.prototype, 'listItems').mockResolvedValue({
+                count: 3,
+                items: testItems,
+                total: 3,
+                offset: 0,
+                limit: 1000,
+                desc: true,
+            });
+            const datasetIterator = datasetClient.iterateBatched();
+            let batchCount = 0;
+            let totalItems = 0;
+            for await (const batch of datasetIterator) {
+                expect(batch).toEqual(testItems);
+                totalItems += batch.length;
+                batchCount++;
+            }
+            expect(batchCount).toBe(1);
+            expect(totalItems).toBe(3);
+            expect(listItemsSpy).toHaveBeenCalledTimes(1);
+            expect(listItemsSpy).toHaveBeenCalledWith({});
+        });
+
+        it('iterates batches of items from the dataset, using pagination', async () => {
+            const listItemsSpy = vi
+                .spyOn(DatasetClient.prototype, 'listItems')
+                .mockResolvedValueOnce({
+                    count: 2,
+                    items: testItems.slice(0, 2),
+                    total: 3,
+                    offset: 0,
+                    limit: 2,
+                    desc: true,
+                })
+                .mockResolvedValueOnce({
+                    count: 1,
+                    items: testItems.slice(2, 3),
+                    total: 3,
+                    offset: 2,
+                    limit: 2,
+                    desc: true,
+                })
+                .mockResolvedValueOnce({
+                    count: 0,
+                    items: [],
+                    total: 3,
+                    offset: 3,
+                    limit: 2,
+                    desc: true,
+                });
+            const datasetIterator = datasetClient.iterateBatched({ pageSize: 2 });
+            let batchCount = 0;
+            let totalItems = 0;
+            const batches: TestItem[][] = [];
+            for await (const batch of datasetIterator) {
+                batches.push(batch);
+                totalItems += batch.length;
+                batchCount++;
+            }
+            expect(batchCount).toBe(2);
+            expect(totalItems).toBe(3);
+            expect(batches[0]).toEqual(testItems.slice(0, 2));
+            expect(batches[1]).toEqual(testItems.slice(2, 3));
             expect(listItemsSpy).toHaveBeenCalledTimes(3);
             expect(listItemsSpy).toHaveBeenNthCalledWith(1, { offset: 0, limit: 2 });
             expect(listItemsSpy).toHaveBeenNthCalledWith(2, { offset: 2, limit: 2 });

--- a/src/clients/dataset-client.test.ts
+++ b/src/clients/dataset-client.test.ts
@@ -89,6 +89,46 @@ describe('ExtDatasetClient', () => {
             expect(listItemsSpy).toHaveBeenNthCalledWith(3, { offset: 4, limit: 2 });
         });
 
+        it('preserves listItems options on every page when paginating', async () => {
+            const listItemsSpy = vi
+                .spyOn(DatasetClient.prototype, 'listItems')
+                .mockResolvedValueOnce({
+                    count: 2,
+                    items: testItems.slice(0, 2),
+                    total: 3,
+                    offset: 0,
+                    limit: 2,
+                    desc: true,
+                })
+                .mockResolvedValueOnce({
+                    count: 1,
+                    items: testItems.slice(2, 3),
+                    total: 3,
+                    offset: 2,
+                    limit: 2,
+                    desc: true,
+                })
+                .mockResolvedValueOnce({
+                    count: 0,
+                    items: [],
+                    total: 3,
+                    offset: 3,
+                    limit: 2,
+                    desc: true,
+                });
+            const datasetIterator = datasetClient.iterate({ pageSize: 2, desc: true });
+            let itemCount = 0;
+            for await (const item of datasetIterator) {
+                expect(item).toEqual(testItems[itemCount]);
+                itemCount++;
+            }
+            expect(itemCount).toBe(3);
+            expect(listItemsSpy).toHaveBeenCalledTimes(3);
+            expect(listItemsSpy).toHaveBeenNthCalledWith(1, { desc: true, offset: 0, limit: 2 });
+            expect(listItemsSpy).toHaveBeenNthCalledWith(2, { desc: true, offset: 2, limit: 2 });
+            expect(listItemsSpy).toHaveBeenNthCalledWith(3, { desc: true, offset: 4, limit: 2 });
+        });
+
         it('yields no items when the dataset is empty', async () => {
             const listItemsSpy = vi.spyOn(DatasetClient.prototype, 'listItems').mockResolvedValue({
                 count: 0,

--- a/src/clients/dataset-client.ts
+++ b/src/clients/dataset-client.ts
@@ -24,33 +24,54 @@ export class ExtDatasetClient<T extends DatasetItem> extends DatasetClient<T> im
         this.context = context;
     }
 
-    async *iterate(options: IterateOptions = {}): AsyncGenerator<T, void, void> {
+    private async *fetchBatches(options: IterateOptions = {}): AsyncGenerator<T[], void, void> {
         const { pageSize, ...listItemOptions } = options;
-        this.context.logger.info('Iterating Dataset', { pageSize }, { url: this.url });
-
-        let totalItems = 0;
 
         if (pageSize) {
             let offset = 0;
             let currentPage = await super.listItems({ ...listItemOptions, offset, limit: pageSize });
             while (currentPage.items.length > 0) {
-                totalItems += currentPage.items.length;
-                for (const item of currentPage.items) {
-                    yield item;
-                }
+                yield currentPage.items;
 
                 offset += pageSize;
                 currentPage = await super.listItems({ offset, limit: pageSize });
             }
         } else {
             const itemList = await super.listItems(listItemOptions);
-            totalItems += itemList.items.length;
-            for (const item of itemList.items) {
+            yield itemList.items;
+        }
+    }
+
+    async *iterate(options: IterateOptions = {}): AsyncGenerator<T, void, void> {
+        const { pageSize } = options;
+        this.context.logger.info('Iterating Dataset', { pageSize }, { url: this.url });
+
+        let totalItems = 0;
+
+        for await (const batch of this.fetchBatches(options)) {
+            totalItems += batch.length;
+            for (const item of batch) {
                 yield item;
             }
         }
 
         this.context.logger.info('Finished reading dataset', { totalItems }, { url: this.url });
+    }
+
+    async *iterateBatched(options: IterateOptions = {}): AsyncGenerator<T[], void, void> {
+        const { pageSize } = options;
+        this.context.logger.info('Iterating Dataset in batches', { pageSize }, { url: this.url });
+
+        let totalItems = 0;
+
+        for await (const batch of this.fetchBatches(options)) {
+            totalItems += batch.length;
+            if (batch.length > 0) {
+                yield batch;
+            }
+        }
+
+        this.context.logger.info('Finished reading dataset in batches', { totalItems }, { url: this.url });
     }
 
     /**

--- a/src/clients/dataset-client.ts
+++ b/src/clients/dataset-client.ts
@@ -34,7 +34,7 @@ export class ExtDatasetClient<T extends DatasetItem> extends DatasetClient<T> im
                 yield currentPage.items;
 
                 offset += pageSize;
-                currentPage = await super.listItems({ offset, limit: pageSize });
+                currentPage = await super.listItems({ ...listItemOptions, offset, limit: pageSize });
             }
         } else {
             const itemList = await super.listItems(listItemOptions);

--- a/src/clients/dataset-client.ts
+++ b/src/clients/dataset-client.ts
@@ -53,9 +53,12 @@ export class ExtDatasetClient<T extends DatasetItem> extends DatasetClient<T> im
         this.context.logger.info('Finished reading dataset', { totalItems }, { url: this.url });
     }
 
-    async *greedyIterate(options: GreedyIterateOptions = {}): AsyncGenerator<T, void, void> {
+    /**
+     * Polls the associated run and yields pages of newly available items until the run reaches a
+     * terminal status, then drains any remaining pages.
+     */
+    private async *greedyFetchBatches(options: GreedyIterateOptions = {}): AsyncGenerator<T[], void, void> {
         const { pageSize = 100, pollIntervalSecs = 10, ...listItemOptions } = options;
-        this.context.logger.info('Greedily iterating Dataset', { pageSize }, { url: this.url });
 
         let readItemsCount = 0;
 
@@ -79,9 +82,7 @@ export class ExtDatasetClient<T extends DatasetItem> extends DatasetClient<T> im
                 limit: pageSize,
             });
             readItemsCount += itemList.count;
-            for (const item of itemList.items) {
-                yield item;
-            }
+            yield itemList.items;
 
             const isTerminal = (ACTOR_JOB_TERMINAL_STATUSES as readonly string[]).includes(run.status);
             if (isTerminal) {
@@ -105,8 +106,28 @@ export class ExtDatasetClient<T extends DatasetItem> extends DatasetClient<T> im
                 break;
             }
             readItemsCount += itemList.count;
-            for (const item of itemList.items) {
+            yield itemList.items;
+        }
+    }
+
+    async *greedyIterate(options: GreedyIterateOptions = {}): AsyncGenerator<T, void, void> {
+        const { pageSize = 100 } = options;
+        this.context.logger.info('Greedily iterating Dataset', { pageSize }, { url: this.url });
+
+        for await (const batch of this.greedyFetchBatches(options)) {
+            for (const item of batch) {
                 yield item;
+            }
+        }
+    }
+
+    async *greedyIterateBatched(options: GreedyIterateOptions = {}): AsyncGenerator<T[], void, void> {
+        const { pageSize = 100 } = options;
+        this.context.logger.info('Greedily iterating Dataset in batches', { pageSize }, { url: this.url });
+
+        for await (const batch of this.greedyFetchBatches(options)) {
+            if (batch.length > 0) {
+                yield batch;
             }
         }
     }

--- a/src/e2e-test.ts
+++ b/src/e2e-test.ts
@@ -16,7 +16,7 @@ if (!input) {
     throw new Error('Input is required');
 }
 
-const { role, orchestratorOptions, waitSeconds, numberToOutput } = input;
+const { role, orchestratorOptions, waitSeconds, numbersToOutput, outputIntervalSecs } = input;
 
 if (role === 'e2e-test') {
     log.info('Starting end-to-end tests');
@@ -30,9 +30,16 @@ if (role === 'e2e-test') {
     await handleResurrectionTest(orchestratorOptions);
 } else if (role === 'child') {
     log.info('Generating output in child run');
-    const outputValue = numberToOutput ?? Math.floor(Math.random() * 100) + 1;
-    log.info(`Output value: ${outputValue}`);
-    await Actor.pushData<Output>({ value: outputValue });
+
+    const outputValues = numbersToOutput ?? [Math.floor(Math.random() * 100) + 1];
+
+    let index = 0;
+    for (const outputValue of outputValues) {
+        log.info(`Output value: ${outputValue}`);
+        await Actor.pushData<Output>({ value: outputValue });
+        if (outputIntervalSecs && index < outputValues.length - 1) await sleep(outputIntervalSecs);
+        index++;
+    }
 }
 
 if (waitSeconds) {

--- a/src/entities/dataset-group.test.ts
+++ b/src/entities/dataset-group.test.ts
@@ -64,4 +64,57 @@ describe('DatasetGroupClass', () => {
 
         expect(readItems).toEqual([{ title: 'A' }, { title: 'B' }, { title: 'C' }]);
     });
+
+    it('can iterate over batches from all the datasets, in order', async () => {
+        interface Item extends DatasetItem {
+            title: string;
+        }
+        const dataset1: PaginatedList<Item> = {
+            count: 2,
+            desc: true,
+            items: [{ title: 'A1' }, { title: 'A2' }],
+            limit: 0,
+            offset: 0,
+            total: 2,
+        };
+        const dataset2: PaginatedList<Item> = {
+            count: 2,
+            desc: true,
+            items: [{ title: 'B1' }, { title: 'B2' }],
+            limit: 0,
+            offset: 0,
+            total: 2,
+        };
+        const dataset3: PaginatedList<Item> = {
+            count: 2,
+            desc: true,
+            items: [{ title: 'C1' }, { title: 'C2' }],
+            limit: 0,
+            offset: 0,
+            total: 2,
+        };
+
+        vi.spyOn(DatasetClient.prototype, 'listItems')
+            .mockResolvedValueOnce(dataset1)
+            .mockResolvedValueOnce(dataset2)
+            .mockResolvedValueOnce(dataset3);
+
+        const mergedDatasets = orchestrator.mergeDatasets(
+            client.dataset<Item>('test-id1'),
+            client.dataset<Item>('test-id2'),
+            client.dataset<Item>('test-id3'),
+        );
+
+        const datasetIterator = mergedDatasets.iterateBatched({});
+        const readBatches: Item[][] = [];
+        for await (const batch of datasetIterator) {
+            readBatches.push(batch);
+        }
+
+        expect(readBatches).toEqual([
+            [{ title: 'A1' }, { title: 'A2' }],
+            [{ title: 'B1' }, { title: 'B2' }],
+            [{ title: 'C1' }, { title: 'C2' }],
+        ]);
+    });
 });

--- a/src/entities/dataset-group.test.ts
+++ b/src/entities/dataset-group.test.ts
@@ -117,4 +117,97 @@ describe('DatasetGroupClass', () => {
             [{ title: 'C1' }, { title: 'C2' }],
         ]);
     });
+
+    it('skips empty datasets when iterating over batches', async () => {
+        interface Item extends DatasetItem {
+            title: string;
+        }
+        const dataset1: PaginatedList<Item> = {
+            count: 2,
+            desc: true,
+            items: [{ title: 'A1' }, { title: 'A2' }],
+            limit: 0,
+            offset: 0,
+            total: 2,
+        };
+        const dataset2: PaginatedList<Item> = {
+            count: 0,
+            desc: true,
+            items: [],
+            limit: 0,
+            offset: 0,
+            total: 0,
+        };
+        const dataset3: PaginatedList<Item> = {
+            count: 2,
+            desc: true,
+            items: [{ title: 'C1' }, { title: 'C2' }],
+            limit: 0,
+            offset: 0,
+            total: 2,
+        };
+
+        vi.spyOn(DatasetClient.prototype, 'listItems')
+            .mockResolvedValueOnce(dataset1)
+            .mockResolvedValueOnce(dataset2)
+            .mockResolvedValueOnce(dataset3);
+
+        const mergedDatasets = orchestrator.mergeDatasets(
+            client.dataset<Item>('test-id1'),
+            client.dataset<Item>('test-id2'),
+            client.dataset<Item>('test-id3'),
+        );
+
+        const datasetIterator = mergedDatasets.iterateBatched({});
+        const readBatches: Item[][] = [];
+        for await (const batch of datasetIterator) {
+            readBatches.push(batch);
+        }
+
+        expect(readBatches).toEqual([
+            [{ title: 'A1' }, { title: 'A2' }],
+            [{ title: 'C1' }, { title: 'C2' }],
+        ]);
+    });
+
+    it('paginates each dataset when iterating over batches with a page size', async () => {
+        interface Item extends DatasetItem {
+            title: string;
+        }
+
+        const page = (items: Item[], offset: number, total: number): PaginatedList<Item> => ({
+            count: items.length,
+            desc: true,
+            items,
+            limit: 2,
+            offset,
+            total,
+        });
+
+        vi.spyOn(DatasetClient.prototype, 'listItems')
+            // First dataset: three items, read in two pages plus a final empty one.
+            .mockResolvedValueOnce(page([{ title: 'A1' }, { title: 'A2' }], 0, 3))
+            .mockResolvedValueOnce(page([{ title: 'A3' }], 2, 3))
+            .mockResolvedValueOnce(page([], 4, 3))
+            // Second dataset: two items, read in one page plus a final empty one.
+            .mockResolvedValueOnce(page([{ title: 'B1' }, { title: 'B2' }], 0, 2))
+            .mockResolvedValueOnce(page([], 2, 2));
+
+        const mergedDatasets = orchestrator.mergeDatasets(
+            client.dataset<Item>('test-id1'),
+            client.dataset<Item>('test-id2'),
+        );
+
+        const datasetIterator = mergedDatasets.iterateBatched({ pageSize: 2 });
+        const readBatches: Item[][] = [];
+        for await (const batch of datasetIterator) {
+            readBatches.push(batch);
+        }
+
+        expect(readBatches).toEqual([
+            [{ title: 'A1' }, { title: 'A2' }],
+            [{ title: 'A3' }],
+            [{ title: 'B1' }, { title: 'B2' }],
+        ]);
+    });
 });

--- a/src/entities/dataset-group.ts
+++ b/src/entities/dataset-group.ts
@@ -15,4 +15,13 @@ export class DatasetGroupClass<T extends DatasetItem> implements DatasetGroup<T>
             }
         }
     }
+
+    async *iterateBatched(options: IterateOptions): AsyncGenerator<T[], void, void> {
+        for (const dataset of this.datasets) {
+            const datasetIterator = dataset.iterateBatched(options);
+            for await (const batch of datasetIterator) {
+                yield batch;
+            }
+        }
+    }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -420,6 +420,21 @@ export interface ExtendedDatasetClient<T extends DatasetItem> extends DatasetCli
     iterate: (options: IterateOptions) => AsyncGenerator<T, void, void>;
 
     /**
+     * Iterates over the items in the dataset in batches.
+     * Batches have the same size as the `pageSize` options, or the size of the dataset if `pageSize` is not specified.
+     *
+     * @param options  includes all the options in `DatasetClientListItemOptions` and `pageSize`
+     * @returns an `AsyncGenerator` which iterates the items in the dataset, in batches
+     *
+     * @example
+     * const batchedDatasetIterator = datasetClient.iterateBatched({ pageSize: 100 });
+     * for await (const batch of batchedDatasetIterator) {
+     *     await Actor.pushData(batch.map(adaptItemToOutputFormat));
+     * }
+     */
+    iterateBatched: (options: IterateOptions) => AsyncGenerator<T[], void, void>;
+
+    /**
      * Iterates over the items in the dataset as they become available, polling the run status
      * at a regular interval and yielding any new items found at each poll.
      *
@@ -459,6 +474,18 @@ export interface DatasetGroup<T extends DatasetItem> {
      * @returns an `AsyncGenerator` which iterates the items in the datasets
      */
     iterate: (options: IterateOptions) => AsyncGenerator<T, void, void>;
+
+    /**
+     * Iterate over all the items from all the dataset, in order, at one time, in batches.
+     * Batches have at most the same size as the `pageSize`, the size of the remaining items of the current `dataset`,
+     * or the size of each dataset if `pageSize` is not specified.
+     *
+     * The option `pageSize` will help avoiding the JavaScript's string limit when deserializing the content.
+     *
+     * @param options includes all the options in `DatasetClientListItemOptions` and `pageSize`
+     * @returns an `AsyncGenerator` which iterates the items in the datasets, in batches
+     */
+    iterateBatched: (options: IterateOptions) => AsyncGenerator<T[], void, void>;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -457,6 +457,31 @@ export interface ExtendedDatasetClient<T extends DatasetItem> extends DatasetCli
      * }
      */
     greedyIterate: (options: GreedyIterateOptions) => AsyncGenerator<T, void, void>;
+
+    /**
+     * Iterates over the items in the dataset in batches as they become available, polling the run status
+     * at a regular interval and yielding any new items found at each poll.
+     * Batches have at most the same size as `pageSize`. Empty batches are never yielded.
+     *
+     * The option `pageSize` will help avoiding the JavaScript's string limit when deserializing the content.
+     * The default value is 100 items.
+     *
+     * The option `pollIntervalSecs` allows customizing how frequently to call the API to check for new items.
+     * The default value is 10 seconds.
+     *
+     * Once the run reaches a terminal status, any remaining items are drained page-by-page until
+     * no more are returned.
+     *
+     * @param options includes all the options in `DatasetClientListItemOptions`, `pageSize`, and `pollIntervalSecs`
+     * @returns an `AsyncGenerator` which iterates the items in the dataset, in batches
+     *
+     * @example
+     * const batchedDatasetIterator = datasetClient.greedyIterateBatched({ pageSize: 100 });
+     * for await (const batch of batchedDatasetIterator) {
+     *     await Actor.pushData(batch.map(adaptItemToOutputFormat));
+     * }
+     */
+    greedyIterateBatched: (options: GreedyIterateOptions) => AsyncGenerator<T[], void, void>;
 }
 
 export interface DatasetGroup<T extends DatasetItem> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Introduces batched dataset iteration (`iterateBatched`) plus “greedy” batched iteration that polls and yields item pages as data becomes available, with shared pagination/polling logic centralized in `ExtDatasetClient` and surfaced through `DatasetGroup`. The change expands the public TypeScript contracts and broadens unit/e2e coverage for empty datasets, progressive availability, merged datasets, and page-size behavior, alongside updating e2e test input handling to support multiple output values. Version is bumped to `0.9.0-rc.2`, aligning with the stated fix for issue `#32`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->