### PR TITLE
feat: coderabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -42,6 +42,9 @@ reviews:
         auto_incremental_review: true
         ignore_title_keywords: ['WIP', '[skip review]']
         ignore_usernames: ['dependabot[bot]', 'renovate[bot]']
+        base_branches:
+            - 'main'
+            - 'dev/.*'
 
     # --- Don't review generated / vendored / large files --------------------
     path_filters:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,10 +11,15 @@ reviews:
     profile: 'chill' # fewer, higher-signal comments (vs. "assertive" = more nitpicks)
 
     # --- Merge gating -------------------------------------------------------
-    # Non-blocking: CodeRabbit posts a status check for visibility only.
+    # `review_status` only controls the review-status message posted in the
+    # walkthrough. The GitHub commit status check is a SEPARATE setting
+    # (`commit_status`), enabled by default and not overridden here.
+    # Note: `request_changes_workflow: false` alone does NOT prevent merge
+    # blocking — if CodeRabbit's check is required by branch protection
+    # (for `main` or `dev/.*`), merges are still gated on it.
     # To let CodeRabbit BLOCK merges (formally "request changes" on issues):
     #   1. set `request_changes_workflow: true` below, and
-    #   2. add CodeRabbit as a required check in branch protection for `main`.
+    #   2. add CodeRabbit as a required check in branch protection for the involved branches.
     request_changes_workflow: false
     review_status: true
 
@@ -64,10 +69,11 @@ reviews:
               small functions over comments — flag comments that merely restate code or are
               stale. Where JSDoc exists on exported APIs, verify it is accurate; do not
               require JSDoc everywhere.
-        - path: '**/*.test.ts'
+        - path: '**/*{.test.ts,-test.ts}'
           instructions: |
-              Unit tests live next to the source file (src/x.ts + src/x.test.ts) and end-to-end
-              tests go inside the test folder (test/x.test.ts).
+              Unit tests are colocated with the source file (src/x.ts + src/x.test.ts).
+              End-to-end tests use the -test.ts suffix: src/e2e-test.ts is the entry point,
+              and e2e suites/helpers live in src/__e2e__/.
               Fixtures go in the nearest __fixtures__/ folder.
               Flag misplaced tests or fixtures.
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,102 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+# CodeRabbit config — tuned for SHORT, substantive reviews.
+# Style/formatting is enforced by CI (ESLint + Prettier) and the pre-commit hook,
+# so CodeRabbit focuses on bugs, security, design, readability, and comment sanity.
+language: 'en-US'
+
+# Global review voice (max 250 chars).
+tone_instructions: 'Be concise—a few sentences, no fluff. Flag bugs, security, logic, design, and readability issues, plus stale or inaccurate comments/JSDoc. Skip style/formatting nits; linting and formatting enforce those in CI.'
+
+reviews:
+    profile: 'chill' # fewer, higher-signal comments (vs. "assertive" = more nitpicks)
+
+    # --- Merge gating -------------------------------------------------------
+    # Non-blocking: CodeRabbit posts a status check for visibility only.
+    # To let CodeRabbit BLOCK merges (formally "request changes" on issues):
+    #   1. set `request_changes_workflow: true` below, and
+    #   2. add CodeRabbit as a required check in branch protection for `main`.
+    request_changes_workflow: false
+    review_status: true
+
+    # --- Keep a tiny summary, drop everything verbose -----------------------
+    high_level_summary: true
+    high_level_summary_instructions: 'Summarize the PR in 2-3 sentences: what changed and why. No file-by-file breakdown, no headings.'
+    high_level_summary_in_walkthrough: false
+    collapse_walkthrough: true
+    changed_files_summary: false
+    sequence_diagrams: false
+    poem: true # kept on purpose — a little spark/heart in the PR summary
+    in_progress_fortune: false # transient "reviewing…" message; never lands in the description
+    estimate_code_review_effort: false
+    assess_linked_issues: false
+    related_issues: false
+    related_prs: false
+    suggested_labels: false
+    suggested_reviewers: false
+    review_details: false
+
+    # --- When it runs -------------------------------------------------------
+    auto_review:
+        enabled: true
+        drafts: false
+        auto_incremental_review: true
+        ignore_title_keywords: ['WIP', '[skip review]']
+        ignore_usernames: ['dependabot[bot]', 'renovate[bot]']
+
+    # --- Don't review generated / vendored / large files --------------------
+    path_filters:
+        - '!**/dist/**'
+        - '!**/storage/**'
+        - '!**/temp/**'
+        - '!**/__fixtures__/**'
+        - '!**/*.tsbuildinfo'
+        - '!package-lock.json'
+        - '!**/.actor/*_schema.json'
+
+    # --- House rules (concise, high-value) ----------------------------------
+    path_instructions:
+        - path: '**/*.ts'
+          instructions: |
+              Prefer clear names and
+              small functions over comments — flag comments that merely restate code or are
+              stale. Where JSDoc exists on exported APIs, verify it is accurate; do not
+              require JSDoc everywhere.
+        - path: '**/*.test.ts'
+          instructions: |
+              Unit tests live next to the source file (src/x.ts + src/x.test.ts) and end-to-end
+              tests go inside the test folder (test/x.test.ts).
+              Fixtures go in the nearest __fixtures__/ folder.
+              Flag misplaced tests or fixtures.
+
+    # --- Static analysis: only what CI doesn't already do -------------------
+    tools:
+        eslint: { enabled: false } # CI runs `npm run lint`
+        biome: { enabled: false } # avoid duplicate JS/TS linting
+        gitleaks: { enabled: true } # secret scanning (not in CI)
+        actionlint: { enabled: true } # GitHub workflow linting
+        hadolint: { enabled: false } # Dockerfile linting
+        markdownlint: { enabled: false } # avoid prose noise
+        languagetool: { enabled: false } # avoid prose/grammar noise
+
+    # --- Don't auto-generate docstrings/tests (keeps output minimal) --------
+    finishing_touches:
+        docstrings: { enabled: false }
+        unit_tests: { enabled: false }
+
+    # --- Suppress nagging pre-merge warnings --------------------------------
+    pre_merge_checks:
+        title: { mode: 'off' }
+        description: { mode: 'off' }
+        docstrings: { mode: 'off' }
+
+chat:
+    art: false # no ASCII art in chat replies
+
+knowledge_base:
+    opt_out: false
+    learnings:
+        scope: 'local' # keep learnings to this repo
+    code_guidelines:
+        enabled: true
+        filePatterns:
+            - 'README.md'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added a comprehensive `.coderabbit.yaml` config to enable concise, high-signal automated CodeRabbit reviews with a “chill” profile and incremental auto-review on `main`/`dev/*`, while skipping WIP/skip-review PRs and common generated/large paths. The setup also tunes merge-gating/review-status behavior, enables secret and workflow scanning (gitleaks/actionlint) while disabling duplicate lint checks (ESLint/biome), suppresses auto-generated docstrings/unit tests and pre-merge title/description/docstring prompts, and scopes “learnings” to this repo’s README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->